### PR TITLE
Misc: fix tag padding

### DIFF
--- a/_sass/_tags.scss
+++ b/_sass/_tags.scss
@@ -5,6 +5,6 @@
 }
 
 .tags-label {
-	padding: 0.3em 0.6em;
+  padding: 0.3em 0.6em;
   @include bordered-element($brand-secondary-color);
 }

--- a/_sass/_tags.scss
+++ b/_sass/_tags.scss
@@ -5,5 +5,6 @@
 }
 
 .tags-label {
+	padding: 0.3em 0.6em;
   @include bordered-element($brand-secondary-color);
 }


### PR DESCRIPTION
the default padding by bootstrap `.label {padding: .2em .6em .3em;}`looks weird, so I unified the top and bottom padding.

article before:
<img width="185" alt="screen shot 2017-08-11 at 5 30 33 pm" src="https://user-images.githubusercontent.com/1209810/29208089-2de79f6e-7ebb-11e7-9a16-c1d65afdec38.png">

article after:
<img width="186" alt="screen shot 2017-08-11 at 5 30 18 pm" src="https://user-images.githubusercontent.com/1209810/29208099-37f7c218-7ebb-11e7-9b2e-91108743ad65.png">

tags before:
<img width="138" alt="screen shot 2017-08-11 at 5 30 22 pm" src="https://user-images.githubusercontent.com/1209810/29208106-3de6e64a-7ebb-11e7-8bd9-9b8019d3e4ba.png">

tags after:

<img width="107" alt="screen shot 2017-08-11 at 5 30 03 pm" src="https://user-images.githubusercontent.com/1209810/29208109-42009ba4-7ebb-11e7-8b2e-43657a9fad96.png">

