### PR TITLE
FIX: update numbers in the post, update dependency version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     jgd (1.8)
       jekyll (>= 1.5.1)
       trollop (= 2.1.2)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.9.0)
     liquid (3.0.6)
     listen (3.0.6)
@@ -136,4 +136,4 @@ DEPENDENCIES
   jgd
 
 BUNDLED WITH
-   1.14.5
+   1.15.3

--- a/_posts/2017-08-08-migrating-existing-datastores.md
+++ b/_posts/2017-08-08-migrating-existing-datastores.md
@@ -7,10 +7,10 @@ authors: [nishant-gupta]
 categories: [Engineering]
 tags: [Back End, Redis]
 comments: true
-excerpt: "At Grab we take pride in creating solutions that impact millions of people in Southeast Asia and as they say, with great power comes great responsibility. As an app with 45 million downloads and 1.1 million drivers, it's our responsibility to keep our systems up-and-running. Any downtime causes drivers to miss earning and passengers to miss their appointments."
+excerpt: "At Grab we take pride in creating solutions that impact millions of people in Southeast Asia and as they say, with great power comes great responsibility. As an app with 55 million downloads and 1.2 million drivers, it's our responsibility to keep our systems up-and-running. Any downtime causes drivers to miss earning and passengers to miss their appointments."
 ---
 
-At Grab we take pride in creating solutions that impact millions of people in Southeast Asia and as they say, with great power comes great responsibility. As an app with 45 million downloads and 1.1 million drivers, it's our responsibility to keep our systems up-and-running. Any downtime causes drivers to miss earning and passengers to miss their appointments.
+At Grab we take pride in creating solutions that impact millions of people in Southeast Asia and as they say, with great power comes great responsibility. As an app with 55 million downloads and 1.2 million drivers, it's our responsibility to keep our systems up-and-running. Any downtime causes drivers to miss earning and passengers to miss their appointments.
 
 It all started when in early 2017, Grab Identity team realised that given the rate at which our user base was growing, we wouldn't be able to sustain the load with our existing single Redis node architecture. We used Redis as a cache to store authentication tokens required for secure mobile client to server communication. These tokens are permanently backed up in an underlying MySQL store. The existing Redis instance was filling at crazy speeds and we were growing at a rate at which we had a maximum of 2 months to react before we would start to ‘choke’ i.e. running out of memory to store more data or run operations on the above mentioned Redis node.
 


### PR DESCRIPTION
Regarding the changes to `Gemfile.lock`, I couldn't run `bundle exec jekyll serve` due to an [incompatibility issue](https://stackoverflow.com/a/41456412/1472186), so I ran `bundle update json` and then it works fine on my local.
 