### PR TITLE
Change width of GitHub stars widget

### DIFF
--- a/_posts/2017-06-03-grabs-front-end-study-guide.md
+++ b/_posts/2017-06-03-grabs-front-end-study-guide.md
@@ -14,7 +14,7 @@ To keep up with Grab’s phenomenal growth, our web team and web platforms have 
 ---
 
 <div class="text-center">
-  <iframe src="https://ghbtns.com/github-btn.html?user=grab&repo=front-end-guide&type=star&count=true&size=large" frameborder="0" scrolling="0" width="142px" height="30px"></iframe>
+  <iframe src="https://ghbtns.com/github-btn.html?user=grab&repo=front-end-guide&type=star&count=true&size=large" frameborder="0" scrolling="0" width="151px" height="30px"></iframe>
 </div>
 
 <img alr="Front End at Grab" src="/img/grabs-front-end-study-guide/front-end-at-grab-banner.png"/>
@@ -405,7 +405,7 @@ As the front end ecosystem grows, we are actively exploring, experimenting and e
 *The original post can be found on [GitHub](https://github.com/grab/front-end-guide). Future updates to the study guide will be made there. If you like what you are reading, give the repository a [star](https://github.com/grab/front-end-guide)! 🌟*
 
 <div class="text-center">
-  <iframe src="https://ghbtns.com/github-btn.html?user=grab&repo=front-end-guide&type=star&count=true&size=large" frameborder="0" scrolling="0" width="142px" height="30px"></iframe>
+  <iframe src="https://ghbtns.com/github-btn.html?user=grab&repo=front-end-guide&type=star&count=true&size=large" frameborder="0" scrolling="0" width="151px" height="30px"></iframe>
 </div>
 
 ### More Reading


### PR DESCRIPTION
Congrats on reaching 10k stars for https://github.com/grab/front-end-guide/! Unfortunately, the widget needs to be longer to handle 5-digits. It's a good problem to have 😄 

**After fix:**

<img width="549" alt="screen shot 2018-02-21 at 2 03 01 pm" src="https://user-images.githubusercontent.com/1315101/36507921-f5876832-170f-11e8-9a04-3d12ebfe2762.png">
