### PR TITLE
consistent author links across the blog

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,11 +24,7 @@ layout: default
             {% assign author = site.data.authors[author_id] %}
             {% if author %}
               &middot;
-              {% if author.github %}
-                <a href="https://github.com/{{ author.github }}" target="_blank" rel="noreferrer noopenner">{{ author.name }}</a>
-              {% else %}
-                {{ author.name }}
-              {% endif %}
+              <a href="/authors#{{ author_id }}">{{ author.name }}</a>
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -22,7 +22,6 @@ body {
   margin: 30px 0;
 }
 
-
 /**
 * Posts List
 */
@@ -157,7 +156,12 @@ a.post-title {
     font-size: 18px;
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin-top: $spacing-unit * 2;
   }
 
@@ -194,15 +198,15 @@ hr.section-divider {
   margin-top: 52px;
 
   &:before {
-    color: rgba(0,0,0,.6);
-    content: '...';
+    color: rgba(0, 0, 0, 0.6);
+    content: "...";
     display: inline-block;
     font-family: $base-font-family-serif;
     font-weight: $font-weight-normal;
     font-style: italic;
     font-size: 24px;
-    letter-spacing: .6em;
-    margin-left: .6em;
+    letter-spacing: 0.6em;
+    margin-left: 0.6em;
     position: relative;
     top: -30px;
   }
@@ -249,6 +253,12 @@ hr.section-divider {
   .posts-summary-list-title {
     margin-bottom: 0;
   }
+}
+
+.post-author-link > a {
+  margin-left: $post-author-thumbnail-size + 9px;
+  font-size: $small-font-size;
+  color: $grey-color-dark;
 }
 
 .posts-search-results {

--- a/authors.html
+++ b/authors.html
@@ -16,6 +16,11 @@ title: Authors
             <div class="post-author-details">
               <h3 class="posts-summary-list-title">{{ author.name }}</h3>
             </div>
+            <div class="post-author-link">
+              {% if author.github %}
+                <a href="https://github.com/{{ author.github }}" target="_blank" rel="noreferrer noopenner">GitHub Profile</a>
+              {% endif %}
+            </div>
           </div>
           <ul class="posts-summary-posts-list">
             {% for post in author.posts %}


### PR DESCRIPTION
fixes #42 

screenshots:
post page:
<img width="745" alt="screen shot 2018-11-08 at 4 27 57 pm" src="https://user-images.githubusercontent.com/1209810/48186717-d0492980-e373-11e8-9c30-11b9d380e289.png">
authors page:
<img width="641" alt="screen shot 2018-11-08 at 4 27 32 pm" src="https://user-images.githubusercontent.com/1209810/48186719-d17a5680-e373-11e8-8617-a832ec857b09.png">
